### PR TITLE
Use the environment (or .env) to pass information to the program

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,16 @@
+# This is an example of the .env needed to run doven-kalender.
+# Copy this file to .env and fill in the required values.
+# Make sure to keep this file, .env, secret and do not share it publicly.
+
+# Intake / kalender keys
+GOOGLE_API_KEY=your_google_api_key_here
+
+# Generator keys
+MISTRAL_API_KEY=your_mistral_api_key_here
+OPENAI_API_KEY=your_openai_api_key_here
+
+# Poster keys
+FACEBOOK_API_KEY=your_facebook_api_key_here
+EMAIL_USERNAME=your_email_username_here
+EMAIL_PASSWORD=your_email_password_here
+EMAIL_HOST=your_email_host_here

--- a/README.md
+++ b/README.md
@@ -4,7 +4,16 @@ Automatiske opslag på Facebook genereret med en LLM ud fra den offentlige IMU k
 
 Der er beskrevet mere om projektets struktur i ARCHITECTURE.md.
 
+Tests kan køres med unittest modulet med
+
+```bash
+python3 -m unittest tests.py
+```
+
 ## Opgaveliste
 
 - [ ] Docker?
-- [ ] Secrets (environment?)
+- [x] Secrets \
+      Vi bruger ´.env´ filen til at gemme hemmeligheder. Det betyder, at man
+      enten kan give programmet miljøvariabler, ellers læser den fra filen.
+      Se `.env.example` for værdier den kan tage imod.

--- a/doven_kalender.py
+++ b/doven_kalender.py
@@ -18,7 +18,9 @@ def weekday_name(weekday_index: int):
 
 if __name__ == "__main__":
     print("Doven Kalender")
-    events = get_events("fj88e45fvuj2hfhl3n1g0mlkus", "AIzaSyDOtGM5jr8bNp1utVpG2_gSRH03RNGBkI8")
+    events = get_events(
+        "fj88e45fvuj2hfhl3n1g0mlkus", "AIzaSyDOtGM5jr8bNp1utVpG2_gSRH03RNGBkI8"
+    )
     if not len(events):
         print("Der er ingen begivenheder i den kommende uge.")
         sys.exit(0)

--- a/environment.py
+++ b/environment.py
@@ -1,0 +1,33 @@
+"""Environment variables for the application.
+This module retrieves environment variables from the environment
+or the .env file if it exists,
+and provides default values for configuration settings
+if none have been set."""
+
+
+
+def load_dotenv() -> None:
+    """Load environment variables from .env file."""
+    with open(".env", "r") as file:
+        import os
+
+        for line in file:
+            if line.strip() and not line.startswith("#"):
+                key, value = line.strip().split("=", 1)
+                key = key.strip()
+                value = value.strip()
+                if key and value:
+                    # According to the documentation os.environ should
+                    # used instead of os.putenv
+                    # https://devdocs.io/python~3.13/library/os#os.putenv
+                    os.environ[key] = value
+
+def get_value(key: str) -> str:
+    """Get the value for the key. If the key is not set,
+    raise a ValueError."""
+    import os
+
+    variable = os.getenv(key)
+    if variable is None:
+        raise ValueError(f"Environment variable '{key}' is not set.")
+    return variable

--- a/tests.py
+++ b/tests.py
@@ -133,5 +133,53 @@ class GeneralTests(unittest.TestCase):
             self.fail(f"Could not find environment files: {e}")
 
 
+class EnvironmentTests(unittest.TestCase):
+    def test_load_dotenv(self):
+        """Test that the .env file is loaded correctly."""
+        from environment import load_dotenv, get_value
+
+        load_dotenv()
+
+        # Check if a known variable is set
+        self.assertNotEqual("", get_value("GOOGLE_API_KEY"))
+
+    def test_get_value(self):
+        """Test that get_value retrieves the correct environment variable."""
+        from environment import load_dotenv, get_value
+
+        load_dotenv()
+
+        # Assuming GOOGLE_API_KEY is set in the .env file
+        api_key = get_value("GOOGLE_API_KEY")
+        self.assertIsInstance(api_key, str)
+        self.assertGreater(len(api_key), 0)
+
+    def test_non_value(self):
+        """Test that get_value fails for nonexisting environment variable."""
+        from environment import load_dotenv, get_value
+
+        load_dotenv()
+
+        # Should throw ValueError since the key does not exist
+        with self.assertRaises(ValueError):
+            get_value("FAKE_API_KEY")
+
+    def test_setting_value(self):
+        """Test that get_value retrieves the correct environment variable
+        after setting it."""
+        from environment import load_dotenv, get_value
+
+        load_dotenv()
+
+        import os
+
+        os.environ["GOOGLE_API_KEY"] = "TEST_VALUE"
+
+        # Assuming GOOGLE_API_KEY is set in the .env file
+        api_key = get_value("GOOGLE_API_KEY")
+        self.assertIsInstance(api_key, str)
+        self.assertEqual(api_key, "TEST_VALUE")
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests.py
+++ b/tests.py
@@ -112,22 +112,26 @@ class GeneralTests(unittest.TestCase):
         try:
             env_keys = set()
             example_keys = set()
-            
-            with open('.env') as env_file, open('.env.example') as example_file:
+
+            with open(".env") as env_file, open(".env.example") as example_file:
                 for line in env_file:
-                    if '=' in line and not line.startswith('#'):
-                        env_keys.add(line.split('=')[0].strip())
-                
+                    if "=" in line and not line.startswith("#"):
+                        env_keys.add(line.split("=")[0].strip())
+
                 for line in example_file:
-                    if '=' in line and not line.startswith('#'):
-                        example_keys.add(line.split('=')[0].strip())
-            
+                    if "=" in line and not line.startswith("#"):
+                        example_keys.add(line.split("=")[0].strip())
+
             missing_keys = env_keys - example_keys
 
-            self.assertEqual(missing_keys, set(), f"Keys in .env missing from .env.example: {missing_keys}")
+            self.assertEqual(
+                missing_keys,
+                set(),
+                f"Keys in .env missing from .env.example: {missing_keys}",
+            )
         except FileNotFoundError as e:
             self.fail(f"Could not find environment files: {e}")
 
 
-    if __name__ == "__main__":
-        unittest.main()
+if __name__ == "__main__":
+    unittest.main()

--- a/tests.py
+++ b/tests.py
@@ -106,5 +106,28 @@ class TestKalender(unittest.TestCase):
             get_events("test_calendar", "test_api_key")
 
 
-if __name__ == "__main__":
-    unittest.main()
+class GeneralTests(unittest.TestCase):
+    def test_env_keys_exist_in_example(self):
+        """Test that all keys in .env exist in .env.example"""
+        try:
+            env_keys = set()
+            example_keys = set()
+            
+            with open('.env') as env_file, open('.env.example') as example_file:
+                for line in env_file:
+                    if '=' in line and not line.startswith('#'):
+                        env_keys.add(line.split('=')[0].strip())
+                
+                for line in example_file:
+                    if '=' in line and not line.startswith('#'):
+                        example_keys.add(line.split('=')[0].strip())
+            
+            missing_keys = env_keys - example_keys
+
+            self.assertEqual(missing_keys, set(), f"Keys in .env missing from .env.example: {missing_keys}")
+        except FileNotFoundError as e:
+            self.fail(f"Could not find environment files: {e}")
+
+
+    if __name__ == "__main__":
+        unittest.main()


### PR DESCRIPTION
Allow passing keys to Google Calendar and LLMs through the environment (and a .env) file. Specific settings, like which LLM to use or where to post should be chosen through runtime arguments and defaulting to e.g. Mistral's Le Chat and email.

What still needs to be done
- [x] Environment file
  - [x] Get value